### PR TITLE
Update nan and callback method

### DIFF
--- a/AsyncWorkers/package-lock.json
+++ b/AsyncWorkers/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     }
   }
 }

--- a/AsyncWorkers/package.json
+++ b/AsyncWorkers/package.json
@@ -8,7 +8,7 @@
     "start": "node ./index.js"
   },
   "dependencies": {
-    "nan": "^2.7.0"
+    "nan": "^2.10.0"
   },
   "repository": {
     "type": "git",

--- a/AsyncWorkers/src/MyAsyncBinding.cc
+++ b/AsyncWorkers/src/MyAsyncBinding.cc
@@ -57,7 +57,7 @@ public:
       Nan::Null(), // no error occured
       Nan::New(workerId).ToLocalChecked()
     };
-		callback->Call(2, argv);
+    Nan::Call(callback->GetFunction(), Nan::GetCurrentContext()->Global(), 2, argv);
 	}
 
 	void HandleErrorCallback() {
@@ -66,8 +66,8 @@ public:
       Nan::New(this->ErrorMessage()).ToLocalChecked(), // return error message
       Nan::Null()
     };
-		callback->Call(2, argv);
-	}
+    Nan::Call(callback->GetFunction(), Nan::GetCurrentContext()->Global(), 2, argv);
+  }
 };
 
 NAN_METHOD(MyAsyncBinding::DoAsyncStuff) {


### PR DESCRIPTION
Great tutorial - it was really helpful. One thing I've found is that in a larger project, a more recent version of nan might get picked up. nan has deprecated `Call`, so we'd see build warnings:
```
  CXX(target) Release/obj.target/myModule/src/index.o
  CXX(target) Release/obj.target/myModule/src/MyAsyncBinding.o
../src/MyAsyncBinding.cc:60:13: warning: 'Call' is deprecated [-Wdeprecated-declarations]
                callback->Call(2, argv);
```
This uses the new `Nan::Call` method. I think it would be really helpful if you could update the tutorial and merge this PR